### PR TITLE
prior-self: add MCP quickstart + Playwright UI smoke docs and script;…

### DIFF
--- a/Prior-Self-MCP/README.md
+++ b/Prior-Self-MCP/README.md
@@ -20,6 +20,16 @@ A small, reusable MCP tool server that gives agents access to prior chat context
 
 See docs/QUICKSTART.md to ingest, index, and run the server.
 
+MCP
+- Streamable HTTP endpoint at `POST /mcp` with tools: search_previous_chats, get_chat_context, list_sessions, summarize_decisions.
+- See docs/MCP-QUICKSTART.md for curl examples.
+
+Dev runner
+- `./run-tests-and-server.sh` — runs tests, seeds transcripts, builds index, smoke tests MCP, then serves (edit defaults or use `.env`).
+
+UI smoke (Playwright)
+- See docs/PLAYWRIGHT-SMOKE.md for a minimal UI smoke that drives `/mcp_ui` and verifies calls.
+
 ## Auth
 - Optional bearer token via `PRIOR_TOKEN` (or `PRIOR_SELF_TOKEN`). If set, all endpoints (including `/mcp`) require `Authorization: Bearer <token>`.
 

--- a/Prior-Self-MCP/docs/MCP-QUICKSTART.md
+++ b/Prior-Self-MCP/docs/MCP-QUICKSTART.md
@@ -1,0 +1,49 @@
+Prior‑Self‑MCP — MCP Quickstart
+
+Overview
+- REST actions: `/actions/search_previous_chats`, `/actions/get_chat_context`, `/actions/list_sessions`, `/actions/summarize_decisions`
+- MCP endpoint: `POST /mcp` (Streamable HTTP JSON‑RPC) implementing `initialize`, `tools/list`, `tools/call` for the tools above
+- Dev pages: `/docs` (Swagger), `/mcp_ui` (MCP playground)
+
+Start server
+```
+python3 Prior-Self-MCP/server/app.py --home "$HOME/.roadnerd/chatdb" --host 127.0.0.1 --port 7070
+```
+
+Seed and index (once)
+```
+export PRIOR_SELF_HOME="$HOME/.roadnerd/chatdb"
+mkdir -p "$PRIOR_SELF_HOME/transcripts"
+python3 Prior-Self-MCP/ingest/append.py --chat-id s1 --project RoadNerd --role assistant --text "tokens brainstorm"
+python3 Prior-Self-MCP/indexer/build_index.py --home "$PRIOR_SELF_HOME"
+```
+
+MCP (curl)
+```
+# initialize
+curl -sS -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
+  http://127.0.0.1:7070/mcp | jq .
+
+# tools/list
+curl -sS -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  http://127.0.0.1:7070/mcp | jq .
+
+# tools/call: search_previous_chats
+curl -sS -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_previous_chats","arguments":{"query":"tokens","project":"RoadNerd","k":5}}}' \
+  http://127.0.0.1:7070/mcp | jq .
+
+# tools/call: get_chat_context
+curl -sS -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_chat_context","arguments":{"chat_id":"s1"}}}' \
+  http://127.0.0.1:7070/mcp | jq .
+```
+
+Auth
+- Optional bearer token via `PRIOR_TOKEN` (or `PRIOR_SELF_TOKEN`). If set, include `Authorization: Bearer <token>` in requests.
+
+Runner
+- `./Prior-Self-MCP/run-tests-and-server.sh` — runs pytest, seeds transcripts, builds index, smoke tests MCP, then serves (edit defaults in the script or via `.env`).
+

--- a/Prior-Self-MCP/docs/PLAYWRIGHT-SMOKE.md
+++ b/Prior-Self-MCP/docs/PLAYWRIGHT-SMOKE.md
@@ -1,0 +1,37 @@
+Playwright UI Smoke — Prior‑Self MCP
+
+Prereqs
+- Node.js 18+
+- Playwright installed locally
+
+Install Playwright (one-time)
+```
+cd Prior-Self-MCP
+npm init -y
+npm i -D playwright
+npx playwright install --with-deps chromium
+```
+
+Seed sample transcript and start the server (if not using the runner)
+```
+export PRIOR_SELF_HOME="$HOME/.roadnerd/chatdb"
+mkdir -p "$PRIOR_SELF_HOME/transcripts"
+python3 ingest/append.py --chat-id s1 --project Smoke --role assistant --text "tokens brainstorm"
+python3 indexer/build_index.py --home "$PRIOR_SELF_HOME"
+python3 server/app.py --home "$PRIOR_SELF_HOME" --host 127.0.0.1 --port 7070
+```
+
+Run the UI smoke
+```
+node Prior-Self-MCP/scripts/ui-playwright.mjs
+```
+
+What it does
+- Opens `/mcp_ui`
+- initialize → tools/list
+- Calls `search_previous_chats` with `{ query: "tokens", project: "Smoke", k: 5 }`
+- Calls `get_chat_context` with `{ chat_id: "s1" }`
+
+Env overrides
+- `PRIOR_BASE` (default `http://127.0.0.1:7070`)
+

--- a/Prior-Self-MCP/scripts/ui-playwright.mjs
+++ b/Prior-Self-MCP/scripts/ui-playwright.mjs
@@ -1,0 +1,56 @@
+// Minimal Playwright UI smoke for Prior‑Self MCP
+// Usage:
+//   node Prior-Self-MCP/scripts/ui-playwright.mjs
+// Requires: npm i -D playwright (and: npx playwright install --with-deps chromium)
+
+import { chromium } from 'playwright';
+
+const BASE = process.env.PRIOR_BASE || 'http://127.0.0.1:7070';
+
+function j(o) { return JSON.stringify(o, null, 2); }
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  try {
+    console.log('Open MCP UI…');
+    await page.goto(`${BASE}/mcp_ui`, { waitUntil: 'domcontentloaded' });
+
+    console.log('Initialize…');
+    await page.getByRole('button', { name: 'initialize' }).click();
+    await page.waitForTimeout(100);
+
+    console.log('Tools list…');
+    await page.getByRole('button', { name: 'tools/list' }).click();
+    await page.waitForTimeout(100);
+
+    console.log('Call search_previous_chats…');
+    await page.getByRole('textbox', { name: 'Tool name' }).fill('search_previous_chats');
+    await page.getByRole('textbox', { name: 'Arguments (JSON)' }).fill(j({
+      query: 'tokens',
+      project: 'Smoke',
+      k: 5
+    }));
+    await page.getByRole('button', { name: 'tools/call' }).click();
+    await page.waitForTimeout(150);
+    const out1 = await page.getByText('{ "jsonrpc": "2.0", "id": 3').first().textContent();
+    if (!out1.includes('structuredContent')) throw new Error('Expected structuredContent in response');
+    console.log('  search_previous_chats OK');
+
+    console.log('Call get_chat_context…');
+    await page.getByRole('textbox', { name: 'Tool name' }).fill('get_chat_context');
+    await page.getByRole('textbox', { name: 'Arguments (JSON)' }).fill(j({ chat_id: 's1' }));
+    await page.getByRole('button', { name: 'tools/call' }).click();
+    await page.waitForTimeout(150);
+    const out2 = await page.getByText('{ "jsonrpc": "2.0", "id": 3').first().textContent();
+    if (!out2.includes('messages')) throw new Error('Expected messages in response');
+    console.log('  get_chat_context OK');
+
+    console.log('UI smoke passed.');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+

--- a/docs/PR_SUMMARY_cls_literal_root_timeout_playwright.md
+++ b/docs/PR_SUMMARY_cls_literal_root_timeout_playwright.md
@@ -1,0 +1,54 @@
+Title: cls: literal search, rg "--" safety, root allowlist + timeout; runner help; Playwright UI smoke; tests
+
+Summary
+- Harden Code‑Log‑Search search tooling and improve dev ergonomics:
+  - Add fixed‑string matching via `literal: true` (maps to `rg -F`).
+  - Prevent ripgrep option injection by inserting `--` before query.
+  - Enforce `root` allowlist: requested root must resolve under `default_code_root` (returns `forbidden_root` otherwise).
+  - Add `timeoutMs` to bound `rg` runtime; SSE reuses durationSec as a time budget.
+  - Improve dev runner: defaults + `.env` support, helpful `--help`, smoke runs MCP init/list and code/logs searches.
+  - Add Playwright UI smoke that drives `/mcp_ui` (initialize → tools/list → literal call → forbidden_root probe).
+- Prior‑Self quality‑of‑life: add a dev runner (tests + seed + smoke + serve) matching the Memory/CLS pattern.
+
+Rationale
+- Security & robustness:
+  - Using `--` stops user queries from being parsed as ripgrep options (e.g., `--pre`).
+  - Root allowlist prevents traversal outside the configured project root.
+  - `literal` improves small‑model reliability; `timeoutMs` mitigates pathological regex/long scans.
+- DX & consistency: all MCPs share a common runner pattern and test pages; UI smoke provides fast verification.
+
+Changes (high‑level)
+- Code‑Log‑Search‑MCP
+  - server/search.py: add `--`, `literal` flag, optional `timeout_ms`, non‑blocking read with kill on timeout.
+  - server/app.py: sanitize root against `default_code_root`, plumb `literal` and `timeoutMs` through REST/MCP/SSE, log DEBUG details.
+  - tests/test_mcp.py: add literal + forbidden_root tests (MCP + REST).
+  - tests/test_search.py: add literal=True case.
+  - docs: SPEC (new params), MCP-QUICKSTART (literal example), PLAYWRIGHT-SMOKE.md, Gemini-Flash-Test-Prompt.md.
+  - scripts/ui-playwright.mjs: minimal Playwright smoke for `/mcp_ui`.
+  - run-tests-and-server.sh: config block, `.env` support, `--help`, dependency checks, improved smoke.
+- Prior‑Self‑MCP
+  - run-tests-and-server.sh: new runner with `.env`, seed + index + smoke (initialize/list/search_previous_chats).
+- Repo hygiene
+  - .gitignore: ignore `.gemini/`, `.tmp_memdb/`, service logs.
+
+Test Plan
+- Unit tests
+  - `pytest -q Code-Log-Search-MCP/tests` → expected: 2 passed, 3 skipped (skips are FastAPI-dependent; run with fastapi/uvicorn installed to enable).
+- Dev runners
+  - CLS: `./Code-Log-Search-MCP/run-tests-and-server.sh` (or `--help`).
+  - Prior‑Self: `./Prior-Self-MCP/run-tests-and-server.sh` (seeds transcripts and verifies MCP).
+- Playwright UI smoke (optional)
+  - `cd Code-Log-Search-MCP && npm i -D playwright && npx playwright install --with-deps chromium`
+  - `node Code-Log-Search-MCP/scripts/ui-playwright.mjs`
+- Manual curls (CLS)
+  - Forbidden root: `curl -s -X POST :7080/actions/search_code -H 'Content-Type: application/json' -d '{"query":"x","root":"/"}'` → 400 `{error:"forbidden_root"}`.
+  - Literal: MCP tools/call with `{ "name":"search_code", "arguments": { "query":"README MCP", "root":"<repo>", "literal": true } }` returns hits.
+
+Security Notes
+- Prevents ripgrep option injection with `--`.
+- Denies roots outside `default_code_root`.
+- Adds `timeoutMs` to reduce risk of DoS via complex patterns/large scans.
+
+Screenshots (optional)
+- See docs/PLAYWRIGHT-SMOKE.md for steps; MCP UI shows initialize/list and returns hits for literal calls.
+


### PR DESCRIPTION
Prior‑Self finish-up
      - Added MCP Quickstart doc: Prior-Self-MCP/docs/MCP-QUICKSTART.md (curl init/list/call examples).
      - Added Playwright UI smoke:
      - Script: Prior-Self-MCP/scripts/ui-playwright.mjs
      - Doc: Prior-Self-MCP/docs/PLAYWRIGHT-SMOKE.md (install + run instructions)
  - Updated README with MCP pointers, runner, and UI smoke.
  - Prior‑Self runner already present: Prior-Self-MCP/run-tests-and-server.sh (tests + seed + smoke + serve).
  - Branches and pushes
      - Code-Log-Search branch (already pushed): cls/literal-root-timeout-playwright
      - Prior-Self branch (new): prior/self-ui-smoke-docs