### PR TITLE
test-start: polish /start JS; app file logging; runner singleton+port…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,18 @@
 - PRs: include summary, rationale, test plan (commands), and any screenshots of `/search` or `/mem` pages if UI changes impact behavior.
 
 ## Security & Configuration Tips
-- Do not commit secrets or local DBs. Use env tokens for auth (`CLS_TOKEN`, `MEM_TOKEN`). Default ports: 7080 (CLS), 7090 (MEM), 7070 (Prior‑Self). Data roots default to `~/.roadnerd/...`.
+- Do not commit secrets or local DBs. Use env tokens for auth (`CLS_TOKEN`, `MEM_TOKEN`). Default ports:
+  - 7010 SysDiag‑MCP (`SYS_HOST`, `SYS_PORT`)
+  - 7020 Docker‑MCP (`DOCKER_MCP_HOST`, `DOCKER_MCP_PORT`)
+  - 7030 Net‑MCP (`NET_HOST`, `NET_PORT`)
+  - 7040 Service‑MCP (`SVC_HOST`, `SVC_PORT`)
+  - 7050 Git‑My‑Way‑MCP (`GMW_HOST`, `GMW_PORT`)
+  - 7060 Test‑Start‑MCP (`TSM_HOST`, `TSM_PORT`)
+  - 7070 Prior‑Self‑MCP
+  - 7080 Code‑Log‑Search‑MCP
+  - 7090 Memory‑MCP
+  - Data roots default to `~/.roadnerd/...`.
+  - Dev runners may free their ports before starting to enforce a singleton.
 
 ## GPT/Claude/Gemini Notes
 - Use repo `.venv` only; runners detect and use it automatically.

--- a/Docker-MCP/README.md
+++ b/Docker-MCP/README.md
@@ -10,3 +10,6 @@ Cautious Docker/Podman management via MCP tools. Read-only by default (info/list
 
 Test UIs
 - `/docs` (Swagger), `/mcp_ui` (MCP playground), `/start` (interactive UI)
+
+Ports
+- Default: `127.0.0.1:7020` (planned)

--- a/Docker-MCP/docs/QUICKSTART.md
+++ b/Docker-MCP/docs/QUICKSTART.md
@@ -13,3 +13,7 @@ Test UIs
 - `/docs` (Swagger) for REST actions
 - `/mcp_ui` (MCP playground): initialize, tools/list, tools/call
 - `/start` (interactive): images/containers list, inspect, logs (SSE), stats (SSE); gated start/stop when enabled
+
+Ports
+- Default: `127.0.0.1:7020`
+- Env (planned): `DOCKER_MCP_HOST`, `DOCKER_MCP_PORT`

--- a/Docker-MCP/docs/SPEC.md
+++ b/Docker-MCP/docs/SPEC.md
@@ -32,10 +32,15 @@ Config (env)
 - `DOCKER_MCP_MUTATE=0|1` (default 0)
 - `DOCKER_MCP_ALLOWED_REGISTRIES=docker.io,ghcr.io`
 - `DOCKER_MCP_ALLOWED_NAMES=app*,service-*`
-- `DOCKER_MCP_LOG_DIR=Docker-MCP/logs`, `DOCKER_MCP_LOG_LEVEL=INFO|DEBUG`
+ - App logging: `DOCKER_MCP_LOG_DIR=Docker-MCP/logs`, `DOCKER_MCP_LOG_FILE=<file>`, `DOCKER_MCP_LOG_TS=0|1`, `DOCKER_MCP_LOG_ROTATE=<bytes>`, `DOCKER_MCP_LOG_BACKUPS=<n>`, `DOCKER_MCP_LOG_LEVEL=INFO|DEBUG`
+ - Network: `DOCKER_MCP_HOST=127.0.0.1`, `DOCKER_MCP_PORT=7020` (default)
 
 Errors
 - `E_TIMEOUT`, `E_FORBIDDEN`, `E_NO_BINARY`, `E_EXEC`, `E_POLICY`
+
+Logging & Audit
+- JSONL audit (planned) per action under `DOCKER_MCP_LOG_DIR` with records like `{ ts, tool, args(masked), duration_ms, exitCode, result }`.
+- Optional app log file as configured via `DOCKER_MCP_LOG_DIR`/`DOCKER_MCP_LOG_FILE` with rotation options.
 
 ## Test UIs
 - `/docs` (Swagger) for REST actions (`/actions/*`).

--- a/Git-My-Way-MCP/docs/QUICKSTART.md
+++ b/Git-My-Way-MCP/docs/QUICKSTART.md
@@ -19,10 +19,14 @@ MCP (examples)
 # initialize
 curl -sS -H 'Accept: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}' \
-  http://127.0.0.1:7050/mcp | jq .
+http://127.0.0.1:7050/mcp | jq .
 
 # tools/list
 curl -sS -H 'Accept: application/json' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
   http://127.0.0.1:7050/mcp | jq .
+
+Ports
+- Default: `127.0.0.1:7050` (used in examples)
+- Env (planned): `GMW_HOST`, `GMW_PORT`
 ```

--- a/Git-My-Way-MCP/docs/SPEC.md
+++ b/Git-My-Way-MCP/docs/SPEC.md
@@ -33,12 +33,14 @@ Security & Policy
 
 Config (env)
 - `GMW_REPO_ROOT=/home/alex/Projects/Reusable-MCP`
-- `GMW_LOG_DIR=Git-My-Way-MCP/logs`, `GMW_LOG_LEVEL=INFO|DEBUG`
+- App logging: `GMW_LOG_DIR=Git-My-Way-MCP/logs`, `GMW_LOG_FILE=<file>`, `GMW_LOG_TS=0|1`, `GMW_LOG_ROTATE=<bytes>`, `GMW_LOG_BACKUPS=<n>`, `GMW_LOG_LEVEL=INFO|DEBUG`
 - `GMW_PROVIDER=github|gitlab` for open_pr (optional)
 - `GMW_PR_TOKEN` (optional) for provider API; treat as secret (never log)
+ - Network: `GMW_HOST=127.0.0.1`, `GMW_PORT=7050` (default)
 
 Logging & Audit
-- JSONL per action: `{ ts, tool, args(masked), duration_ms, result: success|error, error? }`
+- JSONL per action (planned): `{ ts, tool, args(masked), duration_ms, result: success|error, error? }`
+- Optional app log file as configured via `GMW_LOG_DIR`/`GMW_LOG_FILE` with rotation options.
 
 MCP JSON-RPC
 - initialize → `{ protocolVersion, capabilities.tools, serverInfo }`

--- a/Net-MCP/README.md
+++ b/Net-MCP/README.md
@@ -10,3 +10,6 @@ Combined network diagnostics: interface/route info, DNS resolve, HTTP reachabili
 
 Test UIs
 - `/docs` (Swagger), `/mcp_ui` (MCP playground), `/start` (interactive UI)
+
+Ports
+- Default: `127.0.0.1:7030` (planned)

--- a/Net-MCP/docs/QUICKSTART.md
+++ b/Net-MCP/docs/QUICKSTART.md
@@ -13,3 +13,7 @@ Test UIs
 - `/docs` (Swagger) for REST actions
 - `/mcp_ui` (MCP playground): initialize, tools/list, tools/call
 - `/start` (interactive): http_check, tcp_port_check, dns_resolve/config, resolved_status, proxy checks
+
+Ports
+- Default: `127.0.0.1:7030`
+- Env (planned): `NET_HOST`, `NET_PORT`

--- a/Net-MCP/docs/SPEC.md
+++ b/Net-MCP/docs/SPEC.md
@@ -21,10 +21,16 @@ Security
 - Read-only commands; timeouts (default 2000ms); allowlist for http_check URLs; no sudo; redact headers/tokens.
 
 Config (env)
-- `NET_TIMEOUT_MS_DEFAULT=2000`, `NET_HTTP_ALLOWLIST=neverssl.com,httpbin.org`, `NET_LOG_DIR`, `NET_TOKEN`
+- `NET_TIMEOUT_MS_DEFAULT=2000`, `NET_HTTP_ALLOWLIST=neverssl.com,httpbin.org`
+- App logging: `NET_LOG_DIR=Net-MCP/logs`, `NET_LOG_FILE=<file>`, `NET_LOG_TS=0|1`, `NET_LOG_ROTATE=<bytes>`, `NET_LOG_BACKUPS=<n>`, `NET_LOG_LEVEL=INFO|DEBUG`, `NET_TOKEN`
+- Network: `NET_HOST=127.0.0.1`, `NET_PORT=7030` (default)
 
 Errors
 - `E_TIMEOUT`, `E_NO_BINARY`, `E_UNSUPPORTED`, `E_DNS_FAIL`, `E_CONN_REFUSED`
+
+Logging & Audit
+- JSONL audit (planned) for key actions under `NET_LOG_DIR` with records like `{ ts, tool, args(masked), duration_ms, status }`.
+- Optional app log file as configured via `NET_LOG_DIR`/`NET_LOG_FILE` with rotation options.
 
 ## Test UIs
 - `/docs` (Swagger) for REST actions (`/actions/*`).

--- a/Service-MCP/README.md
+++ b/Service-MCP/README.md
@@ -9,3 +9,6 @@ Phase-1 service diagnostics: service_status, list_failed_units, journal_tail. Sc
 
 Test UIs
 - `/docs` (Swagger), `/mcp_ui` (MCP playground), `/start` (interactive UI)
+
+Ports
+- Default: `127.0.0.1:7040` (planned)

--- a/Service-MCP/docs/QUICKSTART.md
+++ b/Service-MCP/docs/QUICKSTART.md
@@ -13,3 +13,7 @@ Test UIs
 - `/docs` (Swagger) for REST actions
 - `/mcp_ui` (MCP playground): initialize, tools/list, tools/call
 - `/start` (interactive): service_status form, list_failed_units, journal_tail viewer
+
+Ports
+- Default: `127.0.0.1:7040`
+- Env (planned): `SVC_HOST`, `SVC_PORT`

--- a/Service-MCP/docs/SPEC.md
+++ b/Service-MCP/docs/SPEC.md
@@ -12,10 +12,16 @@ Security
 - Read-only diagnostics; timeouts; redact sensitive content from logs.
 
 Config (env)
-- `SVC_TIMEOUT_MS_DEFAULT=2000`, `SVC_MAX_LINES=120`, `SVC_LOG_DIR`, `SVC_TOKEN`
+- `SVC_TIMEOUT_MS_DEFAULT=2000`, `SVC_MAX_LINES=120`
+- App logging: `SVC_LOG_DIR=Service-MCP/logs`, `SVC_LOG_FILE=<file>`, `SVC_LOG_TS=0|1`, `SVC_LOG_ROTATE=<bytes>`, `SVC_LOG_BACKUPS=<n>`, `SVC_LOG_LEVEL=INFO|DEBUG`, `SVC_TOKEN`
+- Network: `SVC_HOST=127.0.0.1`, `SVC_PORT=7040` (default)
 
 Errors
 - `E_NO_BINARY` (no systemctl/journalctl), `E_TIMEOUT`, `E_UNSUPPORTED`
+
+Logging & Audit
+- JSONL audit (planned) under `SVC_LOG_DIR` for actions like service_status and journal_tail.
+- Optional app log file as configured via `SVC_LOG_DIR`/`SVC_LOG_FILE` with rotation options.
 
 ## Test UIs
 - `/docs` (Swagger) for REST actions (`/actions/*`).

--- a/SysDiag-MCP/README.md
+++ b/SysDiag-MCP/README.md
@@ -10,3 +10,6 @@ Combined system diagnostics: ports/processes, OS info, CPU/mem, storage usage an
 
 Test UIs
 - `/docs` (Swagger), `/mcp_ui` (MCP playground), `/start` (interactive UI)
+
+Ports
+- Default: `127.0.0.1:7010` (planned)

--- a/SysDiag-MCP/docs/QUICKSTART.md
+++ b/SysDiag-MCP/docs/QUICKSTART.md
@@ -13,3 +13,7 @@ Test UIs
 - `/docs` (Swagger) for REST actions
 - `/mcp_ui` (MCP playground): initialize, tools/list, tools/call
 - `/start` (interactive): listening_sockets, who_uses_port, os_info, cpu_mem_info, disk_usage, top_consumers
+
+Ports
+- Default: `127.0.0.1:7010`
+- Env (planned): `SYS_HOST`, `SYS_PORT`

--- a/SysDiag-MCP/docs/SPEC.md
+++ b/SysDiag-MCP/docs/SPEC.md
@@ -15,10 +15,15 @@ Security
 - psutil-first; read-only; timeouts; path allowlists for top_consumers.
 
 Config (env)
-- `SYS_LOG_DIR`, `SYS_TOKEN`
+- App logging: `SYS_LOG_DIR=SysDiag-MCP/logs`, `SYS_LOG_FILE=<file>`, `SYS_LOG_TS=0|1`, `SYS_LOG_ROTATE=<bytes>`, `SYS_LOG_BACKUPS=<n>`, `SYS_LOG_LEVEL=INFO|DEBUG`, `SYS_TOKEN`
+- Network: `SYS_HOST=127.0.0.1`, `SYS_PORT=7010` (default)
 
 Errors
 - `E_NO_BINARY`, `E_TIMEOUT`, `E_FORBIDDEN`, `E_UNSUPPORTED`
+
+Logging & Audit
+- JSONL audit (planned) for diagnostics run under `SYS_LOG_DIR`.
+- Optional app log file as configured via `SYS_LOG_DIR`/`SYS_LOG_FILE` with rotation options.
 
 ## Test UIs
 - `/docs` (Swagger) for REST actions (`/actions/*`).

--- a/Test-Start-MCP/README.md
+++ b/Test-Start-MCP/README.md
@@ -11,3 +11,7 @@ Status: Implemented. Endpoints: `/actions/run_script`, `/actions/list_allowed`, 
 
 Test UIs
 - `/docs` (Swagger), `/mcp_ui` (MCP playground), `/start` (interactive UI)
+
+Ports
+- Default host/port: `127.0.0.1:7060` (set via `TSM_HOST`, `TSM_PORT`).
+- The runner enforces a singleton: it frees the port before starting to avoid stale processes.

--- a/Test-Start-MCP/docs/PLAYWRIGHT-SMOKE.md
+++ b/Test-Start-MCP/docs/PLAYWRIGHT-SMOKE.md
@@ -12,6 +12,7 @@ Options
 - `TSM_TOKEN=…` to set bearer auth; script stores it in localStorage for `/mcp_ui`.
 - `TSM_PLAYWRIGHT_SCRIPT=…` absolute path to an allow‑listed script (default uses Memory-MCP runner in this repo).
 - `HEADFUL=1` to show the browser.
+- `TSM_PW_OUT=Test-Start-MCP/.pw-artifacts` to change artifacts output directory (screenshots, console log).
 
 What it checks
 - `/mcp_ui` initialize and tools/list flows.
@@ -22,6 +23,7 @@ What it checks
   - Run Script (SSE) and receive stdout/stderr/end
   - Open Logs Stream and receive events
   - Get Stats and Health
+  - Negative checks (best-effort): bad args and forbidden path return 400/403; search_logs returns totals.
 
 Notes
 - Server logs are written to `Test-Start-MCP/logs/` (see SPEC for details).

--- a/Test-Start-MCP/docs/QUICKSTART.md
+++ b/Test-Start-MCP/docs/QUICKSTART.md
@@ -5,7 +5,8 @@ One venv per repo (auto‑used by runners)
 - Runners discover `./.venv/bin/python` automatically; activation is optional.
 
 Run
-- `./Test-Start-MCP/run-tests-and-server.sh` (runs tests if pytest installed, then starts on :7060)
+- `./Test-Start-MCP/run-tests-and-server.sh` (runs tests if pytest installed, frees the port, then starts on `TSM_HOST:TSM_PORT`)
+- Defaults: `TSM_HOST=127.0.0.1`, `TSM_PORT=7060` — override via env
 - Or: `python3 Test-Start-MCP/server/app.py --host 127.0.0.1 --port 7060`
 
 Endpoints

--- a/Test-Start-MCP/docs/SPEC.md
+++ b/Test-Start-MCP/docs/SPEC.md
@@ -45,11 +45,12 @@ Security & Policy
 Config (env)
 - `TSM_ALLOWED_ROOT`, `TSM_ALLOWED_SCRIPTS`, `TSM_ALLOWED_ARGS`, `TSM_ENV_ALLOWLIST`
 - `TSM_TIMEOUT_MS_DEFAULT=90000`, `TSM_MAX_OUTPUT_BYTES=262144`, `TSM_MAX_LINE_BYTES=8192`
-- `TSM_LOG_DIR=Test-Start-MCP/logs`, `TSM_LOG_LEVEL=INFO|DEBUG`
+- Network: `TSM_HOST=127.0.0.1`, `TSM_PORT=7060` (default)
+- Logging (app): `TSM_LOG_DIR`, `TSM_LOG_FILE`, `TSM_LOG_TS=0|1`, `TSM_LOG_ROTATE=<bytes>`, `TSM_LOG_BACKUPS=<n>`, `TSM_LOG_LEVEL=INFO|DEBUG`
 
 Logging & Audit
-- JSONL: `{ ts, tool, path, args, duration_ms, exitCode, result, truncated, requester? }`
-- File logging under `TSM_LOG_DIR`.
+- JSONL audit per execution: `{ ts, tool, path, args, duration_ms, exitCode, result, truncated, requester? }` (files `exec-YYYYMMDD.jsonl` under `TSM_LOG_DIR`)
+- Optional app logging under `TSM_LOG_DIR` or `TSM_LOG_FILE` with rotation.
 
 MCP JSON‑RPC
 - initialize → `{ protocolVersion, capabilities.tools, serverInfo }`
@@ -60,6 +61,9 @@ Test UIs
 - `/docs` (Swagger) for REST
 - `/mcp_ui` (MCP playground): initialize, list, run_script
 - `/start` (interactive): run_script (REST+SSE), list_allowed, logs_stream, get_stats, health
+
+Singleton policy
+- One instance per machine: the dev runner frees the configured port before starting to avoid stale processes.
 
 Attach‑on‑Request
 - If the model requests `test-start/run_script`, attach server and call it. Prefer SSE for live output.

--- a/Test-Start-MCP/run-tests-and-server.sh
+++ b/Test-Start-MCP/run-tests-and-server.sh
@@ -4,11 +4,42 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
 
+# Network (edit if needed)
+HOST="${TSM_HOST:-127.0.0.1}"
+PORT="${TSM_PORT:-7060}"
+
+# ----- Configurable policy/env (edit as needed) -----
+# Default to allowing scripts only within this service folder.
+export TSM_ALLOWED_ROOT="${TSM_ALLOWED_ROOT:-$ROOT_DIR}"
+# Allow this service's runner by default; add more paths separated by ':'
+# Include local runner and probe script by default (colon-separated)
+export TSM_ALLOWED_SCRIPTS="${TSM_ALLOWED_SCRIPTS:-$ROOT_DIR/run-tests-and-server.sh:$ROOT_DIR/scripts/probe.py}"
+# Allowed flags for run scripts (comma-separated)
+export TSM_ALLOWED_ARGS="${TSM_ALLOWED_ARGS:---no-tests,--kill-port,--smoke,--host,--port,--default-code-root,--logs-root,--home,--repeat,--sleep-ms,--exit-code,--stderr-lines,--bytes,--json,--ping}"
+# Env vars that may be passed through to child processes
+export TSM_ENV_ALLOWLIST="${TSM_ENV_ALLOWLIST:-CLS_TOKEN,PRIOR_TOKEN,MEM_TOKEN}"
+# Logging
+export TSM_LOG_DIR="${TSM_LOG_DIR:-$ROOT_DIR/logs}"
+export TSM_LOG_LEVEL="${TSM_LOG_LEVEL:-INFO}"
+
 # Prefer repo-level .venv python; fallback to system python3
 if [ -x "$REPO_ROOT/.venv/bin/python" ]; then
   PY_EXE="$REPO_ROOT/.venv/bin/python"
 else
   PY_EXE="python3"
+fi
+
+# Free the port if occupied (singleton server)
+echo "[prep] Ensuring nothing listens on $HOST:$PORT …"
+if command -v lsof >/dev/null 2>&1; then
+  PIDS="$(lsof -ti TCP:${PORT} -sTCP:LISTEN 2>/dev/null || true)"
+  if [ -n "$PIDS" ]; then
+    echo "[prep] Killing PIDs on :$PORT: $PIDS"
+    kill $PIDS 2>/dev/null || true; sleep 0.3; kill -9 $PIDS 2>/dev/null || true
+  fi
+fi
+if command -v fuser >/dev/null 2>&1; then
+  fuser -k -TERM "${PORT}/tcp" 2>/dev/null || true; sleep 0.3; fuser -k -KILL "${PORT}/tcp" 2>/dev/null || true
 fi
 
 echo "[1/2] Running tests…"
@@ -18,6 +49,10 @@ else
   echo "pytest not installed; skipping tests."
 fi
 
-echo "[2/2] Starting server on :7060 (Ctrl+C to stop)"
-exec "$PY_EXE" "$ROOT_DIR/server/app.py" --host 127.0.0.1 --port 7060
+# Ensure probe script is executable
+if [ -f "$ROOT_DIR/scripts/probe.py" ]; then
+  chmod +x "$ROOT_DIR/scripts/probe.py" || true
+fi
 
+echo "[2/2] Starting server on $HOST:$PORT (Ctrl+C to stop)"
+exec "$PY_EXE" "$ROOT_DIR/server/app.py" --host "$HOST" --port "$PORT"

--- a/Test-Start-MCP/scripts/probe.py
+++ b/Test-Start-MCP/scripts/probe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import time
+import json
+
+def main():
+    p = argparse.ArgumentParser(description='Probe script for Test-Start-MCP')
+    p.add_argument('--repeat', type=int, default=3, help='number of stdout lines to print')
+    p.add_argument('--stderr-lines', type=int, default=1, help='number of stderr lines to print')
+    p.add_argument('--sleep-ms', type=int, default=100, help='sleep between lines (ms)')
+    p.add_argument('--bytes', type=int, default=0, help='emit a blob of N bytes on stdout at end')
+    p.add_argument('--exit-code', type=int, default=0, help='exit code to return')
+    p.add_argument('--json', action='store_true', help='emit a final JSON line')
+    p.add_argument('--ping', action='store_true', help='print ping ticks')
+    p.add_argument('--smoke', action='store_true', help='quick smoke: 2 lines out, 1 err')
+    args = p.parse_args()
+
+    rep = args.repeat
+    errn = args.stderr_lines
+    slp = max(0, args.sleep_ms) / 1000.0
+    if args.smoke:
+        rep = 2
+        errn = 1
+        slp = 0.05
+
+    for i in range(rep):
+        print(f"probe: line {i+1}/{rep}")
+        if args.ping:
+            print(f"probe: ping {i}")
+        sys.stdout.flush()
+        time.sleep(slp)
+
+    for j in range(errn):
+        print(f"probe: warn {j+1}/{errn}", file=sys.stderr)
+        sys.stderr.flush()
+        time.sleep(slp)
+
+    if args.bytes and args.bytes > 0:
+        sys.stdout.write('X' * args.bytes + '\n')
+        sys.stdout.flush()
+
+    if args.json:
+        obj = {
+            'ok': args.exit_code == 0,
+            'repeat': rep,
+            'stderr_lines': errn,
+            'sleep_ms': int(slp*1000),
+        }
+        print(json.dumps(obj))
+        sys.stdout.flush()
+
+    return sys.exit(int(args.exit_code))
+
+if __name__ == '__main__':
+    main()
+

--- a/Test-Start-MCP/server/policy.py
+++ b/Test-Start-MCP/server/policy.py
@@ -103,6 +103,10 @@ def _validate_args(args: List[str]) -> Tuple[bool, Optional[Dict[str, str]]]:
             arg = arg.strip()
             if arg:
                 allowed.add(arg)
+    value_flags = {
+        '--host', '--port', '--default-code-root', '--logs-root', '--home',
+        '--repeat', '--sleep-ms', '--exit-code', '--stderr-lines', '--bytes'
+    }
     i = 0
     while i < len(args):
         tok = args[i]
@@ -110,7 +114,7 @@ def _validate_args(args: List[str]) -> Tuple[bool, Optional[Dict[str, str]]]:
             if tok not in allowed:
                 return False, {'code': 'E_BAD_ARG', 'message': f'flag not allowed: {tok}'}
             # Flags expecting a value
-            if tok in ('--host', '--port', '--default-code-root', '--logs-root', '--home'):
+            if tok in value_flags:
                 if i + 1 >= len(args):
                     return False, {'code': 'E_BAD_ARG', 'message': f'missing value for {tok}'}
                 val = args[i + 1]
@@ -370,4 +374,3 @@ def tool_schemas() -> List[Dict[str, Any]]:
             'outputSchema': {'type': 'object', 'properties': {'scripts': {'type': 'array', 'items': {'type': 'object'}}}, 'required': ['scripts']}
         }
     ]
-


### PR DESCRIPTION
## Summary
  - `/start` UI made robust (no f-string), default script injected
  - Added app logging options for Test-Start-MCP (file, rotate, TS)
  - Runner enforces singleton, supports TSM_HOST/TSM_PORT
  - Added probe script and extended allowed flags
  - Documented default ports for pipeline MCPs + logging guidelines (DIR/FILE/TS/ROTATE/BACKUPS)

  ## Testing
  - Tests: 31 passed, 1 skipped
  - Playwright MCP validated MCP and REST/SSE flows using probe

  🤖 Generated with [Claude Code](https://claude.ai/code)