### PR TITLE
test-start-mcp: Phase A preflight tokens + Phase B overlays + landing

### DIFF
--- a/Test-Start-MCP/docs/POLICY-ROADMAP.md
+++ b/Test-Start-MCP/docs/POLICY-ROADMAP.md
@@ -1,0 +1,104 @@
+# Test‑Start‑MCP — Policy, Pre‑flight, Roles (Roadmap)
+
+This document captures our current implementation, constraints discovered in practice, and the plan to make policy and pre‑flight work reliably across platforms (Gemini, Codex, etc.).
+
+## Motivation
+- Platforms often hide `initialize` results and HTTP headers from the model.
+- Models are stateless; they may not bootstrap a session unless a planner forces it.
+- The human must retain control — approvals are human‑only and audited.
+- We need “check before run” to hold regardless of client quirks, and give agents human‑actionable guidance inline.
+
+## Shipped Now
+- Tools and guidance
+  - `check_script` returns `allowed`, `reasons`, `suggestions`, and an absolute `adminLink` with a pasteable `responseTemplate`.
+  - `start_here` tool returns the same guidance for platforms that hide `initialize`.
+  - `tools/list` adds x-guidance hints (use `check_script` before `run_script`).
+  - `initialize` (if surfaced) embeds `policy.preflight`, `allowedRoot`, and instructions.
+- Preflight token (Phase A)
+  - When `allowed=true`, `check_script` returns `{ preflightToken, expiresAt }`.
+  - `run_script` (MCP + REST) and SSE accept optional `preflight_token`.
+  - When `TSM_REQUIRE_PREFLIGHT=1`, server enforces that a valid `preflight_token` or a legacy session preflight exists; otherwise returns guidance with `adminLink` and `responseTemplate`.
+- Enforcement (optional)
+  - `TSM_REQUIRE_PREFLIGHT=1` enforces “check → run” using a simple in‑memory cache keyed by session header (for our UI).
+- Admin & audit
+  - Add/remove rules (Path vs Scope), Assign Profile Overlay, policy audit tail.
+  - Execution audit (exec-YYYYMMDD.jsonl).
+  - Request/access audit (access-YYYYMMDD.jsonl) of REST/MCP calls (sanitized).
+- UI refactor
+  - All UIs use templates and static assets for easy debugging.
+
+## Key Changes for Platforms
+- Agents will always see absolute admin links and pasteable response templates in `check_script` (and later in `run_script` errors) — no need to read docs or headers.
+- Optional session overlays remain for our UIs; we avoid hard reliance on headers for third‑party clients.
+
+## Plan (Phased)
+
+### Phase A — Preflight Token (Implemented)
+- `check_script` now returns `{ preflightToken, expiresAt }` (HMAC‑signed, bound to `{ path, args[] }`).
+- `run_script` (MCP + REST) and SSE accept `preflight_token`; if `TSM_REQUIRE_PREFLIGHT=1` and token missing/invalid/expired/mismatch → server rejects with user‑facing guidance (absolute `adminLink` + `responseTemplate`).
+- Rationale: Platforms reliably pass arguments; this enforces “check before run” without `initialize` or headers.
+
+Token format
+- Compact JWT‑style: base64url(header).base64url(payload).base64url(HMAC‑SHA256).
+- Header: `{ alg: "HS256", typ: "JWT" }`.
+- Payload: `{ p: <abs canonical path>, ah: sha256(JSON.stringify(args)), iat, exp, v:1 }`.
+- Secret: `TSM_PREFLIGHT_SECRET` (ephemeral fallback with warning when enforcement is on).
+
+### Phase B — Human‑managed overlays (in progress)
+- Admin UI: “Generate Session ID for Role” — implemented
+  - New panel on `/admin` to generate a session id, choose a profile and TTL, and assign an overlay; supports selectors.
+- Tools accept `sessionId` and optional `role` in arguments — implemented
+  - MCP: `check_script(..., sessionId?, role?)`, `run_script(..., sessionId?, role?, preflight_token?)`.
+  - REST/SSE also accept `sessionId` (body/query) in addition to `X-TSM-Session` header.
+- Overlays with selectors — implemented
+  - Overlay dataclass extended with optional `path`, `scopeRoot`, `patterns`.
+  - Evaluation priority: overlay‑path > overlay‑scope > overlay‑session (no selector) > rule > globals.
+  - Caps clamping and flag intersections honor the selected overlay.
+
+### Phase C — Principal overlays (longer term)
+- Overlays keyed by Authorization token fingerprint (“principal”) for real clients.
+- Admin: “Apply to” radio → Principal | Session | Global.
+
+## Admin UI Polish
+- Tabs or radios: Path Rule | Scope Rule (hide irrelevant fields in each mode).
+- Show Allowed Root (TSM_ALLOWED_ROOT) chip; disable Add if outside root.
+- Suggestions when `?path=…` present (prefill scope root + basename pattern).
+- TTL presets (600/3600/86400). Optional “Validate” button (read‑only call to `check_script`).
+
+## Roles (Practical & Safe)
+- `role` arg in tools is for audit and hints; it does not widen privileges.
+- Overlays define effective permissions:
+  - Flags: global ∩ overlay.flagsAllowed ∩ rule.flagsAllowed (minus denied).
+  - Caps: clamp timeout/output to min(overlay.caps, rule.caps).
+- Default when no `sessionId` provided: your chosen default during testing (later safer default or mandatory preflight).
+
+## Settings & Hints
+- `.gemini/settings.json` can include a non‑binding `hints` block for humans/wrappers (roles, response templates). It does not change model behavior.
+ - New env: `TSM_PREFLIGHT_SECRET` to sign tokens (recommended when `TSM_REQUIRE_PREFLIGHT=1`).
+
+## Security & Logging
+- Boundaries: Always enforce `TSM_ALLOWED_ROOT` and path canonicalization.
+- Audits: `exec-YYYYMMDD.jsonl` (execution), `policy-YYYYMMDD.jsonl` (admin mutations), `access-YYYYMMDD.jsonl` (requests; sanitized).
+- No secrets logged (Authorization/Cookie are scrubbed in access logs).
+
+## Compatibility
+- All changes are additive; preflight_token, sessionId, and role are optional tool arguments.
+- In‑memory session preflight cache remains for our UIs; token enforcement is the agent‑agnostic mechanism.
+ - With `TSM_REQUIRE_PREFLIGHT=0`, tokens are optional and not enforced; existing flows remain unchanged.
+
+## Test & Validate
+- Playwright MCP: run with `--isolated` to avoid Chrome profile locks.
+- Flows:
+  - `/mcp_ui`: initialize → tools/list → start_here → check_script → run_script (with preflight_token in Phase A).
+  - `/start`: list_allowed → run_script (REST) → SSE → logs → stats/health.
+  - `/admin`: add path/scope rule, remove rule, Assign Profile Overlay (Generate Session ID), audit tail.
+- Examine `access-YYYYMMDD.jsonl` to see what arguments platforms send (e.g., sessionId, role).
+
+## Quick Reference
+- Env: `TSM_ALLOWED_ROOT`, `TSM_ALLOWED_SCRIPTS`, `TSM_ALLOWED_ARGS`, `TSM_ADMIN_TOKEN`, `TSM_REQUIRE_PREFLIGHT`, `TSM_PREFLIGHT_TTL_SEC`, `TSM_LOG_DIR`.
+- Endpoints: `/mcp`, `/mcp_ui`, `/start`, `/admin`, `/admin/state`, `/admin/allowlist/add|remove`, `/admin/session/profile`, `/sse/run_script_stream`, `/actions/*`.
+- Logs: `exec-YYYYMMDD.jsonl`, `policy-YYYYMMDD.jsonl`, `access-YYYYMMDD.jsonl` under `TSM_LOG_DIR`.
+
+## Next Work Items (to resume)
+1) Phase B: add optional `sessionId` param to MCP tools; Admin “Generate Session ID for Role”; overlays with path/scope selectors; UI tabs (Path/Scope).
+2) Optional: principal overlays (by token fingerprint), and preflight read‑only audit entries.

--- a/Test-Start-MCP/server/templates/landing.html
+++ b/Test-Start-MCP/server/templates/landing.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test-Start-MCP — Landing</title>
+  <style>
+    body{font-family:system-ui,sans-serif;background:#0b1220;color:#e0e6f0;padding:24px}
+    a{color:#60a5fa;text-decoration:none}
+    a:hover{text-decoration:underline}
+    section{background:#111827;border:1px solid #1f2937;border-radius:8px;padding:16px;margin-bottom:16px}
+    code,pre{background:#0b1220;border:1px solid #1f2937;border-radius:6px;padding:4px}
+    ul{margin:8px 0 0 18px}
+  </style>
+  </head>
+  <body>
+    <h1>Test‑Start‑MCP</h1>
+    <p>Safely start and smoke‑test local MCP services from models when their sandboxes can’t run scripts. This service enforces allowlists, pre‑flight, overlays, and audits to keep human approval in control.</p>
+
+    <section>
+      <h2>Quick Links (UIs)</h2>
+      <ul>
+        <li><a href="/mcp_ui">MCP Playground</a> — initialize, list tools, call tools</li>
+        <li><a href="/start">Runner UI</a> — list allowed, run (REST), run (SSE), logs, stats/health</li>
+        <li><a href="/admin">Admin</a> — add/remove rules, assign overlays, view policy audit</li>
+        <li><a href="/docs">Swagger Docs</a> and <a href="/redoc">ReDoc</a></li>
+        <li><a href="/healthz">Health</a></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Docs (inline)</h2>
+      <ul>
+        <li><a href="/docs/view?name=readme">README</a></li>
+        <li><a href="/docs/view?name=quickstart">Quickstart</a></li>
+        <li><a href="/docs/view?name=e2e">E2E Tutorial</a></li>
+        <li><a href="/docs/view?name=policy">Policy Roadmap (backlog)</a></li>
+        <li><a href="/docs/view?name=playwright">Playwright UI Smoke</a></li>
+        <li><a href="/docs/view?name=adminspec">Admin + Pre‑flight Spec</a></li>
+        <li><a href="/docs/view?name=spec">Service Spec</a></li>
+        <li><a href="/docs/view?name=testplan">Test Plan</a></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Tips</h2>
+      <ul>
+        <li>Set <code>TSM_TOKEN</code> in localStorage to authenticate UIs.</li>
+        <li>Use <code>check_script</code> before <code>run_script</code>; when enforced, include <code>preflight_token</code>.</li>
+        <li>Assign session overlays in Admin to clamp runtime caps per project or path.</li>
+      </ul>
+    </section>
+  </body>
+  </html>
+

--- a/Test-Start-MCP/tests/test_admin_profiles_dropdown_and_sort.py
+++ b/Test-Start-MCP/tests/test_admin_profiles_dropdown_and_sort.py
@@ -1,0 +1,55 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def require_fastapi():
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"fastapi not available: {e}")
+
+
+def test_admin_state_overlays_sorted_and_profiles_exposed(tmp_path, monkeypatch):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ADMIN_TOKEN', 'adm')
+
+    # Seed state with profiles and two overlays out of order
+    state_fp = tmp_path / 'allowlist.json'
+    seed = {
+        'version': 1,
+        'rules': [],
+        'overlays': [
+            {'sessionId': 's1', 'profile': 'dev', 'expiresAt': '2099-01-01T00:00:00+00:00', 'id': 'o1', 'createdAt': '2020-01-01T00:00:00+00:00'},
+            {'sessionId': 's2', 'profile': 'tester', 'expiresAt': '2099-01-02T00:00:00+00:00', 'id': 'o2', 'createdAt': '2021-01-01T00:00:00+00:00'}
+        ],
+        'profiles': {
+            'tester': {'caps': {'maxTimeoutMs': 10000, 'maxBytes': 65536, 'maxStdoutLines': 200, 'concurrency': 1}, 'flagsAllowed': ['--smoke']},
+            'dev': {'caps': {'maxTimeoutMs': 90000, 'maxBytes': 262144, 'maxStdoutLines': 1500, 'concurrency': 2}, 'flagsAllowed': ['--smoke']}
+        }
+    }
+    state_fp.write_text(json.dumps(seed), encoding='utf-8')
+    monkeypatch.setenv('TSM_ALLOWED_FILE', str(state_fp))
+
+    app = create_app()
+    client = TestClient(app)
+
+    r = client.get('/admin/state', headers={'Authorization': 'Bearer adm'})
+    assert r.status_code == 200
+    j = r.json()
+    # Sorted newest first (createdAt 2021 before 2020)
+    ids = [o['id'] for o in j['overlays']]
+    assert ids == ['o2', 'o1']
+    # Profiles exposed
+    assert set(j['profiles'].keys()) == {'tester', 'dev'}
+

--- a/Test-Start-MCP/tests/test_landing_and_docs_view.py
+++ b/Test-Start-MCP/tests/test_landing_and_docs_view.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def require_fastapi():
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"fastapi not available: {e}")
+
+
+def test_landing_and_docs_view(tmp_path, monkeypatch):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+
+    # Ensure allowed root so app starts
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+
+    app = create_app()
+    client = TestClient(app)
+
+    r = client.get('/')
+    assert r.status_code == 200
+    assert 'Test‑Start‑MCP' in r.text or 'Test-Start-MCP' in r.text
+
+    # README is expected to exist and contain project name
+    r2 = client.get('/docs/view', params={'name': 'readme'})
+    assert r2.status_code == 200
+    assert 'Test-Start-MCP' in r2.text or 'Test‑Start‑MCP' in r2.text

--- a/Test-Start-MCP/tests/test_multi_overlays.py
+++ b/Test-Start-MCP/tests/test_multi_overlays.py
@@ -1,0 +1,99 @@
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def require_fastapi():
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"fastapi not available: {e}")
+
+
+def _make_script(tmp_path: Path, lines: str, name: str) -> Path:
+    p = tmp_path / name
+    p.write_text("#!/usr/bin/env python3\n" + lines, encoding='utf-8')
+    mode = p.stat().st_mode
+    p.chmod(mode | stat.S_IXUSR)
+    return p
+
+
+def _auth_hdr(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_multi_overlays_selection_and_remove(tmp_path: Path, monkeypatch):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+
+    proj = tmp_path / 'proj'
+    proj.mkdir()
+    subA = proj / 'A'
+    subA.mkdir()
+    subB = proj / 'B'
+    subB.mkdir()
+
+    slowA = _make_script(subA, "import time\ntime.sleep(0.15)\nprint('A')\n", 'run.py')
+    slowB = _make_script(subB, "import time\ntime.sleep(0.15)\nprint('B')\n", 'run.py')
+
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', f"{slowA}:{slowB}")
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--smoke')
+    monkeypatch.setenv('TSM_ADMIN_TOKEN', 'adm')
+    # Preflight enforcement off for simplicity
+    monkeypatch.setenv('TSM_REQUIRE_PREFLIGHT', '0')
+
+    # Profiles: tiny vs large
+    state_fp = tmp_path / 'allowlist.json'
+    seed = {
+        'version': 1,
+        'rules': [],
+        'overlays': [],
+        'profiles': {
+            'tiny': {'caps': {'maxTimeoutMs': 50, 'maxBytes': 65536, 'maxStdoutLines': 200, 'concurrency': 1}, 'flagsAllowed': ['--smoke']},
+            'large': {'caps': {'maxTimeoutMs': 5000, 'maxBytes': 262144, 'maxStdoutLines': 1500, 'concurrency': 2}, 'flagsAllowed': ['--smoke']}
+        }
+    }
+    state_fp.write_text(json.dumps(seed), encoding='utf-8')
+    monkeypatch.setenv('TSM_ALLOWED_FILE', str(state_fp))
+
+    app = create_app()
+    client = TestClient(app)
+
+    # Assign two overlays for same session: session-only large (fallback) and scope A tiny (restrictive)
+    r0 = client.post('/admin/session/profile', headers=_auth_hdr('adm'), json={'sessionId': 'sess-multi', 'profile': 'large', 'ttlSec': 300})
+    assert r0.status_code == 200 and r0.json().get('ok') is True
+    r1 = client.post('/admin/session/profile', headers=_auth_hdr('adm'), json={'sessionId': 'sess-multi', 'profile': 'tiny', 'ttlSec': 300, 'scopeRoot': str(subA), 'patterns': ['**']})
+    assert r1.status_code == 200 and r1.json().get('ok') is True
+
+    # Run in A -> should timeout due to tiny
+    jA = client.post('/actions/run_script', headers={'X-TSM-Session': 'sess-multi'}, json={'path': str(slowA), 'args': [], 'timeout_ms': 5000}).json()
+    assert jA['exitCode'] == -1
+    # Run in B -> should pass due to large fallback
+    jB = client.post('/actions/run_script', headers={'X-TSM-Session': 'sess-multi'}, json={'path': str(slowB), 'args': [], 'timeout_ms': 5000}).json()
+    assert jB['exitCode'] == 0
+
+    # Remove the scope overlay; ensure fallback applies to A as well now (no timeout)
+    st = client.get('/admin/state', headers=_auth_hdr('adm')).json()
+    # Find an overlay with scopeRoot=subA
+    oid = None
+    for o in st.get('overlays', []):
+        if o.get('scopeRoot') == str(subA):
+            oid = o.get('id')
+            break
+    assert oid
+    rrm = client.post('/admin/overlay/remove', headers=_auth_hdr('adm'), json={'id': oid})
+    assert rrm.status_code == 200 and rrm.json().get('ok') is True
+
+    jA2 = client.post('/actions/run_script', headers={'X-TSM-Session': 'sess-multi'}, json={'path': str(slowA), 'args': [], 'timeout_ms': 5000}).json()
+    assert jA2['exitCode'] == 0
+

--- a/Test-Start-MCP/tests/test_overlay_selectors.py
+++ b/Test-Start-MCP/tests/test_overlay_selectors.py
@@ -1,0 +1,131 @@
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def require_fastapi():
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"fastapi not available: {e}")
+
+
+def _make_script(tmp_path: Path, lines: str, name: str) -> Path:
+    p = tmp_path / name
+    p.write_text("#!/usr/bin/env python3\n" + lines, encoding='utf-8')
+    mode = p.stat().st_mode
+    p.chmod(mode | stat.S_IXUSR)
+    return p
+
+
+def _auth_hdr(token: str):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_overlay_path_selector_clamps_only_matching(tmp_path: Path, monkeypatch):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+
+    slow = _make_script(tmp_path, "import time\ntime.sleep(0.2)\nprint('slow')\n", 'slow.py')
+    fast = _make_script(tmp_path, "print('fast')\n", 'fast.py')
+
+    # Env
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', f"{slow}:{fast}")
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--smoke')
+    monkeypatch.setenv('TSM_ADMIN_TOKEN', 'adm')
+
+    # Seed a tight profile
+    state_fp = tmp_path / 'allowlist.json'
+    seed = {
+        'version': 1,
+        'rules': [],
+        'overlays': [],
+        'profiles': {
+            'tiny': {'caps': {'maxTimeoutMs': 50, 'maxBytes': 65536, 'maxStdoutLines': 200, 'concurrency': 1}, 'flagsAllowed': ['--smoke']}
+        }
+    }
+    state_fp.write_text(json.dumps(seed), encoding='utf-8')
+    monkeypatch.setenv('TSM_ALLOWED_FILE', str(state_fp))
+
+    app = create_app()
+    client = TestClient(app)
+
+    # Assign PATH overlay for slow.py only
+    r0 = client.post('/admin/session/profile', headers=_auth_hdr('adm'), json={'sessionId': 'sess-path', 'profile': 'tiny', 'ttlSec': 300, 'path': str(slow)})
+    assert r0.status_code == 200 and r0.json().get('ok') is True
+
+    # Preflight to record
+    client.post('/actions/check_script', headers={'X-TSM-Session': 'sess-path'}, json={'path': str(slow), 'args': []})
+
+    # Run slow with large timeout -> should time out due to clamp
+    r1 = client.post('/actions/run_script', headers={'X-TSM-Session': 'sess-path'}, json={'path': str(slow), 'args': [], 'timeout_ms': 5000})
+    assert r1.status_code == 200 and r1.json()['exitCode'] == -1
+
+    # Run fast with same session and large timeout -> should NOT be clamped (no overlay match)
+    r2 = client.post('/actions/run_script', headers={'X-TSM-Session': 'sess-path'}, json={'path': str(fast), 'args': [], 'timeout_ms': 5000})
+    assert r2.status_code == 200 and r2.json()['exitCode'] in (0, 1)
+
+
+def test_mcp_sessionId_argument_used_for_caps(tmp_path: Path, monkeypatch):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+
+    slow = _make_script(tmp_path, "import time\ntime.sleep(0.2)\nprint('slow')\n", 'slow2.py')
+
+    # Env
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', str(slow))
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--smoke')
+    monkeypatch.setenv('TSM_ADMIN_TOKEN', 'adm')
+    # Preflight enforcement off for simplicity here
+    monkeypatch.setenv('TSM_REQUIRE_PREFLIGHT', '0')
+
+    # Profiles
+    state_fp = tmp_path / 'allowlist.json'
+    seed = {
+        'version': 1,
+        'rules': [],
+        'overlays': [],
+        'profiles': {
+            'tiny': {'caps': {'maxTimeoutMs': 50, 'maxBytes': 65536, 'maxStdoutLines': 200, 'concurrency': 1}, 'flagsAllowed': ['--smoke']}
+        }
+    }
+    state_fp.write_text(json.dumps(seed), encoding='utf-8')
+    monkeypatch.setenv('TSM_ALLOWED_FILE', str(state_fp))
+
+    app = create_app()
+    client = TestClient(app)
+
+    # Assign session-only overlay for sess-arg
+    r0 = client.post('/admin/session/profile', headers=_auth_hdr('adm'), json={'sessionId': 'sess-arg', 'profile': 'tiny', 'ttlSec': 300})
+    assert r0.status_code == 200 and r0.json().get('ok') is True
+
+    # Call MCP run_script with sessionId in arguments; expect clamp -> timeout (-1)
+    body = {
+        "jsonrpc": "2.0",
+        "id": 77,
+        "method": "tools/call",
+        "params": {
+            "name": "run_script",
+            "arguments": {"path": str(slow), "args": [], "timeout_ms": 5000, "sessionId": "sess-arg"}
+        }
+    }
+    r1 = client.post('/mcp', json=body)
+    assert r1.status_code == 200
+    j1 = r1.json()['result']['structuredContent']
+    assert j1['exitCode'] == -1
+

--- a/Test-Start-MCP/tests/test_preflight_token.py
+++ b/Test-Start-MCP/tests/test_preflight_token.py
@@ -1,0 +1,141 @@
+import json
+import os
+import stat
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def require_fastapi():
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient  # noqa: F401
+    except Exception as e:
+        pytest.skip(f"fastapi not available: {e}")
+
+
+def _make_script(tmp_path: Path, lines: str, name: str = 'script.py') -> Path:
+    p = tmp_path / name
+    p.write_text("#!/usr/bin/env python3\n" + lines, encoding='utf-8')
+    mode = p.stat().st_mode
+    p.chmod(mode | stat.S_IXUSR)
+    return p
+
+
+def _mk_app(tmp_path: Path):
+    require_fastapi()
+    from fastapi.testclient import TestClient
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from server.app import create_app
+    app = create_app()
+    return TestClient(app)
+
+
+def test_mcp_preflight_token_flow(tmp_path: Path, monkeypatch):
+    """Enforcement on: check -> token -> run ok; missing token fails."""
+    script = _make_script(tmp_path, """
+print('ok')
+import sys
+sys.exit(0)
+""")
+
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', str(script))
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--no-tests;--kill-port;--smoke;--host;--port')
+    monkeypatch.setenv('TSM_REQUIRE_PREFLIGHT', '1')
+
+    client = _mk_app(tmp_path)
+
+    # Missing token should fail
+    body = {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "tools/call",
+        "params": {
+            "name": "run_script",
+            "arguments": {"path": str(script), "args": []}
+        }
+    }
+    r = client.post('/mcp', json=body)
+    assert r.status_code == 200
+    resp = r.json()
+    assert resp['result']['isError'] is True
+    assert resp['result']['structuredContent']['error']['code'] == 'E_POLICY'
+
+    # check_script to get token
+    body = {
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "tools/call",
+        "params": {
+            "name": "check_script",
+            "arguments": {"path": str(script), "args": []}
+        }
+    }
+    r = client.post('/mcp', json=body)
+    assert r.status_code == 200
+    token = r.json()['result']['structuredContent'].get('preflightToken')
+    assert token
+
+    # run_script with token succeeds
+    body = {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "method": "tools/call",
+        "params": {
+            "name": "run_script",
+            "arguments": {"path": str(script), "args": [], "preflight_token": token}
+        }
+    }
+    r = client.post('/mcp', json=body)
+    assert r.status_code == 200
+    resp = r.json()
+    assert resp['result']['isError'] is False
+    assert resp['result']['structuredContent']['exitCode'] == 0
+
+
+def test_rest_preflight_token_missing_then_ok(tmp_path: Path, monkeypatch):
+    script = _make_script(tmp_path, "print('hello')")
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', str(script))
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--smoke')
+    monkeypatch.setenv('TSM_REQUIRE_PREFLIGHT', '1')
+
+    client = _mk_app(tmp_path)
+
+    # Missing token -> 428
+    r = client.post('/actions/run_script', json={"path": str(script), "args": []})
+    assert r.status_code == 428
+
+    # Get token via REST check_script
+    r = client.post('/actions/check_script', json={"path": str(script), "args": []})
+    assert r.status_code == 200
+    token = r.json().get('preflightToken')
+    assert token
+
+    # Run with token -> 200
+    r = client.post('/actions/run_script', json={"path": str(script), "args": [], "preflight_token": token})
+    assert r.status_code == 200
+    assert r.json().get('exitCode') == 0
+
+
+def test_preflight_token_mismatch(tmp_path: Path, monkeypatch):
+    script = _make_script(tmp_path, "print('x')")
+    monkeypatch.setenv('TSM_ALLOWED_ROOT', str(tmp_path))
+    monkeypatch.setenv('TSM_ALLOWED_SCRIPTS', str(script))
+    monkeypatch.setenv('TSM_ALLOWED_ARGS', '--smoke')
+    monkeypatch.setenv('TSM_REQUIRE_PREFLIGHT', '1')
+
+    client = _mk_app(tmp_path)
+
+    # Get token for [] args
+    r = client.post('/actions/check_script', json={"path": str(script), "args": []})
+    token = r.json().get('preflightToken')
+    assert token
+    # Try to run with different args -> 428
+    r = client.post('/actions/run_script', json={"path": str(script), "args": ["--smoke"], "preflight_token": token})
+    assert r.status_code == 428


### PR DESCRIPTION
 - Summary
      - Phase A: Implement stateless preflight_token and enforce across REST/MCP/SSE when TSM_REQUIRE_PREFLIGHT=1. Tokens returned by check_script on allowed=true.
      - Phase B: Add session overlays with path/scope selectors; admin UI to assign overlays and remove specific overlays; overlays sorted newest-first; profiles dropdown in Admin.
      - Landing: New / landing with links to MCP Playground (/mcp_ui), Runner UI (/start), Admin (/admin), Swagger (/docs), ReDoc (/redoc), Health (/healthz). Inline docs viewer at /docs/view
  for README, Quickstart, E2E, Policy, Playwright, Admin spec, Service spec, Test plan.
  - Changes
      - server/app.py: preflight token helpers and enforcement; accept preflight_token/sessionId; admin overlay add/remove; overlay sorting; landing and docs viewer; template deprecation
  fallback.
      - server/policy_store.py: Overlay extended with id, createdAt, and selectors; evaluation updated for path > scope > session; effective caps respect selectors.
      - server/templates/landing.html: new landing template.
      - docs/POLICY-ROADMAP.md: Phase A implemented; Phase B in progress.
      - tests: coverage for tokens, overlays, selectors, admin profiles dropdown, landing/docs viewer.
  - Compatibility
      - Backward compatible: Tokens optional when TSM_REQUIRE_PREFLIGHT=0. Session overlays remain supported. Principal overlays deferred to backlog.
  - Test Plan
      - pytest -q Test-Start-MCP/tests (all pass)
      - ./Test-Start-MCP/run-tests-and-server.sh
      - Open / for landing, click into /mcp_ui, /start, /admin
      - /docs/view?name=policy to verify inline docs